### PR TITLE
feat(#13): implement a basic option to use a custom tsconfig.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Plays nicely with [Prettier](https://prettier.io) and [lint-staged](https://gith
 > organize-imports-cli [--list-different] files...
 ```
 
-Files can be specific `ts` and `js` files or `tsconfig.json`, in which case the whole project is processed.
+Files can be specific `ts` and `js` files or `tsconfig[.*].json`, in which case the whole project is processed.
 
 Files containing the substring `// organize-imports-ignore` are skipped.
 

--- a/cli.js
+++ b/cli.js
@@ -73,7 +73,8 @@ function main(filePaths, listDifferent) {
     if (tsConfigFilePath && !projectEntry) {
       const project = new Project({ tsConfigFilePath, manipulationSettings });
 
-      if (path.basename(filePath).toLowerCase() === "tsconfig.json") {
+      const filename = path.basename(filePath).toLowerCase();
+      if (filename.match(/tsconfig(.*).json/g) !== null) {
         projects[tsConfigFilePath] = {
           files: "all",
           project,

--- a/cli.js
+++ b/cli.js
@@ -73,8 +73,7 @@ function main(filePaths, listDifferent) {
     if (tsConfigFilePath && !projectEntry) {
       const project = new Project({ tsConfigFilePath, manipulationSettings });
 
-      const filename = path.basename(filePath).toLowerCase();
-      if (filename.match(/tsconfig(.*).json/g) !== null) {
+      if (/^tsconfig.*\.json$/gi.test(path.basename(filePath))) {
         projects[tsConfigFilePath] = {
           files: "all",
           project,


### PR DESCRIPTION
Hello, 

I'm working on few projects with Angular stack. Default file is not tsconfig.json but tsconfig.app.json or tsconfig.lib.json. 
A quick fix is to check that passed argument is a tsconfig[.*].json file. 

Tests are good.

Best regards, 
Vincent PECQUERIE. 