### PR TITLE
don't load all files in a project upfront

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -71,7 +71,7 @@ function main(filePaths, listDifferent) {
     const detectNewLineKind = !!ec.end_of_line;
 
     if (tsConfigFilePath && !projectEntry) {
-      const project = new Project({ tsConfigFilePath, manipulationSettings });
+      const project = new Project({ tsConfigFilePath, manipulationSettings, skipAddingFilesFromTsConfig: true });
 
       if (/^tsconfig.*\.json$/gi.test(path.basename(filePath))) {
         projects[tsConfigFilePath] = {

--- a/tests/__snapshots__/excluded.test.js.snap
+++ b/tests/__snapshots__/excluded.test.js.snap
@@ -19,16 +19,16 @@ Array [
   Object {
     "content": "import { log } from \\"./util\\";
 
-log(\\"bar\\");
+log(\\"foo\\");
 ",
-    "filename": "included.ts",
+    "filename": "excluded.ts",
   },
   Object {
     "content": "import { log } from \\"./util\\";
 
-log(\\"foo\\");
+log(\\"bar\\");
 ",
-    "filename": "excluded.ts",
+    "filename": "included.ts",
   },
 ]
 `;


### PR DESCRIPTION
One thing I noticed was that for formatting a single file in a large project, organize-imports-cli could be very slow. This PR just doesn't do that loading upfront so that it's quicker to organize imports for a small set of files in a large codebase.

My Tests:
 - already organized imports: .96s (this PR) vs 25.02s (master)
 - 1 unused import 1 transposed import: 2.11s (this PR) vs 26.31 (master)

My assessment was that the ordering change in the snapshot was harmless because the fundamental behavior was unchanged but let me know if that's a real failure.