### PR TITLE
Add `--ignore-punctuation` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ Files can be specific `ts` and `js` files or `tsconfig[.*].json`, in which case 
 Files containing the substring `// organize-imports-ignore` are skipped.
 
 The `--list-different` flag prints a list of files with unorganized imports. No files are modified.
+
+When using `--list-different`, you can use `--ignore-punctuation` to not fail if there's only changes in punctuation.

--- a/cli.js
+++ b/cli.js
@@ -18,8 +18,9 @@ if (process.argv.length < 3) {
   printUsage();
 } else {
   main(
-    process.argv.slice(2).filter(arg => arg !== "--list-different"),
-    process.argv.includes("--list-different")
+    process.argv.slice(2).filter(arg => arg !== "--list-different" && arg !== "--ignore-punctuation"),
+    process.argv.includes("--list-different"),
+    process.argv.includes("--ignore-punctuation")
   );
 }
 
@@ -29,13 +30,15 @@ if (process.argv.length < 3) {
  * @param {string[]} filePaths
  * @param {boolean} listDifferent
  */
-function main(filePaths, listDifferent) {
-  const logger = listDifferent
+function main(filePaths, listDifferent, ignorePunctuation) {
+  const logger = 
+  listDifferent
     ? {
         write() {},
         writeLine() {}
       }
-    : {
+    :
+     {
         write: process.stdout.write.bind(process.stdout),
         writeLine: console.log.bind(console)
       };
@@ -138,7 +141,7 @@ function main(filePaths, listDifferent) {
 
       if (
         listDifferent
-          ? importsBefore === serializeImports(sourceFile)
+          ? differentImports(importsBefore, serializeImports(sourceFile), ignorePunctuation)
           : fullText === sourceFile.getFullText()
       ) {
         logger.writeLine("");
@@ -169,6 +172,15 @@ function main(filePaths, listDifferent) {
   }
 
   logger.writeLine(chalk`{yellowBright Done!}`);
+}
+
+function stripPunctuation(imports) {
+  return imports.replace(/;/g, "").replace(/,}/g,"}")
+}
+
+function differentImports(before, after, ignorePunctuation) {
+  if (!ignorePunctuation) return before === after
+  return stripPunctuation(before) === stripPunctuation(after)
 }
 
 /**

--- a/tests/__snapshots__/punctuation.test.js.snap
+++ b/tests/__snapshots__/punctuation.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`with --ignore-punctuation (status) 1`] = `0`;
+
+exports[`with --ignore-punctuation (stderr) 1`] = `""`;
+
+exports[`with --ignore-punctuation (stdout) 1`] = `""`;
+
+exports[`with --ignore-punctuation (write) 1`] = `Array []`;
+
+exports[`without --ignore-punctuation (status) 1`] = `2`;
+
+exports[`without --ignore-punctuation (stderr) 1`] = `""`;
+
+exports[`without --ignore-punctuation (stdout) 1`] = `
+"<dir>/file1.js
+<dir>/file2.js
+"
+`;
+
+exports[`without --ignore-punctuation (write) 1`] = `Array []`;

--- a/tests/cli/punctuation/file1.js
+++ b/tests/cli/punctuation/file1.js
@@ -1,0 +1,3 @@
+import fs from "fs"
+
+console.log(fs);

--- a/tests/cli/punctuation/file2.js
+++ b/tests/cli/punctuation/file2.js
@@ -1,0 +1,7 @@
+import fs from "fs"
+import { 
+    aap,
+    noot,
+} from "mies"
+
+console.log(fs, aap, noot);

--- a/tests/punctuation.test.js
+++ b/tests/punctuation.test.js
@@ -1,0 +1,10 @@
+const runCli = require("./run-cli");
+
+describe("with --ignore-punctuation", () => {
+  runCli("cli/punctuation", ["--list-different", "--ignore-punctuation", "file1.js", "file2.js"]).test();
+});
+
+describe("without --ignore-punctuation", () => {
+    runCli("cli/punctuation", ["--list-different", "file1.js", "file2.js"]).test();
+  });
+  


### PR DESCRIPTION
I'd like to run `--list-different` on CI, but because prettier runs after organize-imports, the committed output of the code in our repo is different from what TypeScript's `organizeImports` produces.

This PR adds a `--ignore-punctuation` flag that, only when using `--list-different`, will not fail when just the punctuation differs from the output generated by typescript.